### PR TITLE
Improve env setup; adjust import/no-extraneous-dependencies to tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@ Plugins and configs used:
 * [eslint-plugin-flowtype](https://yarnpkg.com/en/package/eslint-plugin-flowtype)
 * [eslint-plugin-jest](https://yarnpkg.com/en/package/eslint-plugin-jest)
 
+Additionally, it sets these environments:
+```json
+{
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true
+  }
+}
+```
+
+And for test files matching default Jest `testMatch`:
+```json
+{
+  "env": {
+    "jest/globals": true
+  }
+}
+```
+
 ## Installation
 
 ```

--- a/index.js
+++ b/index.js
@@ -7,20 +7,16 @@ module.exports = {
     'prettier/react'
   ],
   env: {
-    'jest/globals': true
+    browser: true,
+    es6: true,
+    node: true
   },
   parser: 'babel-eslint',
   plugins: ['flowtype', 'jest', 'prettier'],
   rules: {
     'flowtype/no-weak-types': 1,
     'flowtype/require-parameter-type': 2,
-    'flowtype/require-return-type': [
-      0,
-      'always',
-      {
-        annotateUndefined: 'never'
-      }
-    ],
+    'flowtype/require-return-type': [0, 'always', {annotateUndefined: 'never'}],
     'flowtype/require-valid-file-annotation': 2,
     'import/extensions': 0,
     'import/no-duplicates': 0,
@@ -36,9 +32,19 @@ module.exports = {
     'prettier/prettier': ['error', 'fb'],
     'react/forbid-prop-types': 1,
     'react/jsx-filename-extension': [0, {extensions: ['.js', '.jsx']}],
+    'import/no-extraneous-dependencies': [
+      'error',
+      {devDependencies: ['**/*.test.js', '**/__tests__/**']}
+    ],
     'react/prefer-stateless-function': 0,
     'react/prop-types': 0,
     'react/require-default-props': 0,
     'react/sort-comp': 0
+  },
+  overrides: {
+    files: ['**/__tests__/**/*.js?(x)', '**/?(*.)(spec|test).js?(x)'],
+    env: {
+      'jest/globals': true
+    }
   }
 };


### PR DESCRIPTION
Hey @satya164, got something for you

Summary:
* add `browser`, `node` and `es6` env
* add `jest/globals` env for test files matching default Jest's `testMatch` config
* setup `import/no-extraneous-dependencies` to work with tests