### PR TITLE
Change trailing commas to es5

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = {
       'error',
       {
         singleQuote: true,
-        trailingComma: 'all'
+        trailingComma: 'es5'
       }
     ],
     'react/forbid-prop-types': 1,


### PR DESCRIPTION
Untranspiled files break in node with `trailingComma: 'all'`. Since this is a global config for all our callstack projects, it's better to have it as `es5` since we don't always transpile.

cc @grabbou